### PR TITLE
example of using `all_resources: true` wildcard channel scoped event trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ $ cd my-app
 
 Open `/triggers/message_posted_event.ts` and update the `channel_ids` value to
 be the channel ID of the channel you'd like your app to respond in.
+Alternatively, you can uncomment the `all_resources` property to have the app
+respond in _all_ channels.
 
 ## Running Your Project Locally
 

--- a/triggers/message_posted_event.ts
+++ b/triggers/message_posted_event.ts
@@ -11,7 +11,8 @@ const trigger: Trigger<typeof ReplyToMessageWorkflow.definition> = {
   event: {
     event_type: TriggerEventTypes.MessagePosted,
     // Update Channel Id on new installs
-    channel_ids: ["REPLACE_WITH_YOUR_CHANNEL_ID"],
+    // channel_ids: ["REPLACE_WITH_YOUR_CHANNEL_ID"],
+    all_resources: true,
     filter: {
       root: {
         operator: "AND",


### PR DESCRIPTION
Mainly for demonstration purposes, as a new feature coming out in the next SDK version.